### PR TITLE
デーモン起動は Process.daemon を使う方式に変更

### DIFF
--- a/docker/resources/scripts/lib/functions.rb
+++ b/docker/resources/scripts/lib/functions.rb
@@ -26,15 +26,16 @@ def shell_exec(*cmd)
   exit_status
 end
 
-# 子プロセスを起動する
+# デーモンプロセスを起動する
 # @param [Array<String>] cmd
-# @param [Boolean] detach 子プロセスを切り離して、親が終了しても ゾンビ状態にならないようにする
-def shell_spawn(*cmd, detach: true)
+# @return [Integer] プロセスID
+def daemon_exec(*cmd)
   cmd_line = cmd.join(' ')
-  log('SHELL_SPAWN:', cmd_line)
-  pid = spawn cmd_line
-  if detach
-    Process.detach pid
+  pid = Process.fork do
+    Process.daemon
+    Process.exec(cmd_line)
   end
+  Process.detach pid
+  log('DAEMON_EXEC:', cmd_line)
   pid
 end

--- a/docker/resources/scripts/lib/socat_manager.rb
+++ b/docker/resources/scripts/lib/socat_manager.rb
@@ -68,7 +68,7 @@ class SocatManager
         return pid
       end
     end
-    pid = shell_spawn cmd  # 子プロセスを起動
+    pid = daemon_exec cmd  # 子プロセスを起動
     _log "started. PID=#{pid} cmd=#{cmd}"
     pid
   end


### PR DESCRIPTION
`Kernel#spawn` を使う方式では、元のRubyプロセスが終了したときに一緒に子プロセスまで終了してしまっていました。
chatGPT に聞いてみたら `nohup` を前につける方法を教えてくれたが、それでも問題は解決しなかった。
`Process.fork` して `Process.daemon` を呼んであげれば、元のRubyプロセスが終了しても子プロセスは稼働し続けるように出来た。