### PR TITLE
support HTTP keepalive for upstreams.

### DIFF
--- a/docker/resources/scripts/config_template_http.erb
+++ b/docker/resources/scripts/config_template_http.erb
@@ -4,6 +4,7 @@
     <% u.dest.each do |p| %>
       server <%= p %>;
     <% end %>
+    keepalive 16;
   }
 <% end %>
 
@@ -48,8 +49,10 @@ server {
         grpc_set_header X-Request-ID $request_id;
         grpc_pass $target_upstream;
      <% else %>
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";  # for HTTP keepalive
 
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $xfp;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;

--- a/docker/resources/scripts/config_template_https.erb
+++ b/docker/resources/scripts/config_template_https.erb
@@ -4,6 +4,7 @@
     <% u.dest.each do |p| %>
       server <%= p %>;
     <% end %>
+    keepalive 16;
   }
 <% end %>
 
@@ -69,8 +70,10 @@ server {
         grpc_set_header X-Request-ID $request_id;
         grpc_pass $target_upstream;
      <% else %>
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";  # for HTTP keepalive
 
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $xfp;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
### 参考

- https://milestone-of-se.nesuke.com/nw-basic/as-nw-engineer/keepalive-tcp-http/
- https://ameblo.jp/dagyah/entry-12396072532.html
- https://blog1.mammb.com/entry/2020/09/06/000000
- https://blog.mothule.com/web/nginx/web-nginx-getting-started-step3-on-mac#keepalive%E3%83%87%E3%82%A3%E3%83%AC%E3%82%AF%E3%83%86%E3%82%A3%E3%83%96