### PR TITLE
WebSocket の疎通を暗黙的にするように設定した

### DIFF
--- a/src/app/config_template_http.erb
+++ b/src/app/config_template_http.erb
@@ -14,6 +14,11 @@ map $http_x_forwarded_proto $xfp {
   "" $scheme;
 }
 
+map $http_connection $conn {
+  default keep-alive;
+  upgrade upgrade;                 # for HTTP keepalive
+}
+
 # --- server definitions for plain HTTP ---
 server {
     server_name  <%= config.domain %>;
@@ -50,7 +55,9 @@ server {
         grpc_pass $target_upstream;
      <% else %>
         proxy_http_version 1.1;
-        proxy_set_header Connection "";  # for HTTP keepalive
+        # for WebSocket
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $conn;
 
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $xfp;

--- a/src/app/config_template_http.erb
+++ b/src/app/config_template_http.erb
@@ -15,8 +15,8 @@ map $http_x_forwarded_proto $xfp {
 }
 
 map $http_connection $conn {
-  default keep-alive;
-  upgrade upgrade;                 # for HTTP keepalive
+  default keep-alive;        # for HTTP keepalive
+  upgrade upgrade;           # for WebSocket
 }
 
 # --- server definitions for plain HTTP ---

--- a/src/app/config_template_https.erb
+++ b/src/app/config_template_https.erb
@@ -15,8 +15,8 @@ map $http_x_forwarded_proto $xfp {
 }
 
 map $http_connection $conn {
-  default keep-alive;
-  upgrade upgrade;                 # for HTTP keepalive
+  default keep-alive;        # for HTTP keepalive
+  upgrade upgrade;           # for WebSocket
 }
 
 # --- server definitions for plain HTTP ---

--- a/src/app/config_template_https.erb
+++ b/src/app/config_template_https.erb
@@ -14,6 +14,11 @@ map $http_x_forwarded_proto $xfp {
   "" $scheme;
 }
 
+map $http_connection $conn {
+  default keep-alive;
+  upgrade upgrade;                 # for HTTP keepalive
+}
+
 # --- server definitions for plain HTTP ---
 server {
     server_name  <%= config.domain %>;
@@ -71,7 +76,9 @@ server {
         grpc_pass $target_upstream;
      <% else %>
         proxy_http_version 1.1;
-        proxy_set_header Connection "";  # for HTTP keepalive
+        # for WebSocket
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $conn;
 
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $xfp;


### PR DESCRIPTION
`proxy_set_header Connection ""` としてしまっていたせいで、WebSocketの疎通ができなくなってしまっていた。
中継元のHTTPヘッダを見て、動的に `Connection` ヘッダを切り替えるようにしました。