### PR TITLE
[WIP]buildxを使ってマルチプラットフォームビルドできるようにした

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,9 @@
 #
 # Usage:
 #   ./build.sh [tag]
+#   tagは省略した場合はシステム日付になります。
 # Example:
+#   ./build.sh
 #   ./build.sh latest
 #
 
@@ -13,6 +15,12 @@ function die(){
 
 SCRIPT_DIR=${SCRIPT_DIR:-$(cd $(dirname $0) && pwd)}
 
+# buildxを使えるか判定する
+ENABLE_BUILD_X=""
+if docker buildx version >/dev/null 2>&1; then
+  ENABLE_BUILD_X=true
+fi
+
 TAG=${1:-`date "+%Y%m%d"`}
 shift
 
@@ -22,12 +30,20 @@ echo building image "$NAME_TAG" ...
 
 cd $SCRIPT_DIR
 
-time docker build --target base -t $NAME_TAG . $@
+if [[ -n "$ENABLE_BUILD_X" ]]; then
+  echo "Using buildx (multi-arch build)"
+  DOCKER_BUILD_COMMAND_BASE="docker buildx build --platform linux/amd64,linux/arm64"
+else
+  echo "Warning: buildx not found. Unable to multi-arch build"
+  DOCKER_BUILD_COMMAND_BASE="docker build"
+fi
+
+time $DOCKER_BUILD_COMMAND_BASE --target base -t $NAME_TAG . $@
 if [ $? -ne 0 ]; then
   exit 1
 fi
 
-time docker build --target tester -t $NAME_TAG-test . $@
+time $DOCKER_BUILD_COMMAND_BASE --target tester -t $NAME_TAG-test . $@
 if [ $? -ne 0 ]; then
   cat <<TEST_MSG
 
@@ -42,7 +58,7 @@ TEST_MSG
   exit 1
 fi
 
-time docker build --target openappsec -t $NAME_TAG-openappsec . $@
+time $DOCKER_BUILD_COMMAND_BASE --target openappsec -t $NAME_TAG-openappsec . $@
 if [ $? -ne 0 ]; then
   exit 1
 fi


### PR DESCRIPTION
arm64版を作れるようにbuildxを使ってビルドできるようにした。
しかし、open-appsecのinstallでエラーが出る。

```
 => [openappsec-install 2/6] RUN curl https://downloads.openappsec.io/open-appsec-install -O                                                                                                                                       0.6s 
 => [openappsec-install 3/6] RUN chmod +x open-appsec-install                                                                                                                                                                      0.1s 
 => ERROR [openappsec-install 4/6] RUN ./open-appsec-install --download                                                                                                                                                           15.7s 
------                                                                                                                                                                                                                                  
 > [openappsec-install 4/6] RUN ./open-appsec-install --download:
0.119 open-appsec for NGINX, Kong and APISIX Installer v1.2245.1
0.119 For release notes and known limitations check:
0.119 https://docs.openappsec.io/release-notes
0.122 Searching local NGINX…
13.51 nginx version found: 1.24.0-2ubuntu7
13.95 Downloading open-appsec NGINX attachment... stored in '/tmp/open-appsec'
14.79 Failed to download nginx-attachment for nginx version: 1.24.0-2ubuntu7
14.79 
14.79 gzip: stdin: not in gzip format
14.79 tar: Child returned status 1
14.79 tar: Error is not recoverable: exiting now
14.80 mv: cannot stat '/tmp/open-appsec/ngx_module_1.24.0-2ubuntu7/libngx_module.so': No such file or directory
15.62 The combination of ubuntu noble on aarch64 is unsupported. Please see docs.openappsec.io
------
Dockerfile:89
--------------------
  87 |     RUN curl https://downloads.openappsec.io/open-appsec-install -O
  88 |     RUN chmod +x open-appsec-install
  89 | >>> RUN ./open-appsec-install --download
  90 |     RUN mkdir -p /outlet
  91 |     RUN mv open-appsec/ngx_module_*/* /outlet/  # ngx_module_1.24.0-2ubuntu7.5/ のようなディレクトリの中身を出力用ディレクトリに移動
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c ./open-appsec-install --download" did not complete successfully: exit code: 1

```

## 原因
```
The combination of ubuntu noble on aarch64 is unsupported. Please see docs.openappsec.io
```
と書かれており、open-appsecのarm64版がサポートされていないと思われる。

## 調査
https://github.com/openappsec/attachment/issues/24
https://github.com/openappsec/attachment#open-appsec-nginx-attachment-compilation-instructions
これらの情報からgit cloneしてきてコンパイルすればできるかもしれない