### PR TITLE
openappsec の libshmem_ipc_2.so のコピー漏れ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ FROM base AS openappsec
 COPY --from=openappsec-install /outlet/libosrc_shmem_ipc.so             /usr/lib/
 COPY --from=openappsec-install /outlet/libosrc_compression_utils.so     /usr/lib/
 COPY --from=openappsec-install /outlet/libosrc_nginx_attachment_util.so /usr/lib/
+COPY --from=openappsec-install /outlet/libshmem_ipc_2.so /usr/lib/
 RUN mkdir -p /usr/lib/nginx/modules/
 COPY --from=openappsec-install /outlet/ngx_cp_attachment_module.so      /usr/lib/nginx/modules/
 

--- a/docker.resources/docker-entrypoint.sh
+++ b/docker.resources/docker-entrypoint.sh
@@ -16,6 +16,22 @@ else
     MONIT_PID=$!
   fi
 
+  # wait for nginx to start
+  echo '--- WAITING FOR NGINX -----'
+  TIMEOUT=30
+  while [ $((TIMEOUT--)) -gt 0 ]; do
+    if [ -f /var/run/nginx.pid ] && kill -0 $(cat /var/run/nginx.pid) 2>/dev/null; then
+      echo "nginx started successfully"
+      break
+    fi
+    sleep 0.5
+  done
+
+  if [ $TIMEOUT -le 0 ]; then
+    echo "ERROR: nginx failed to start within timeout" >&2
+    exit 1
+  fi
+
   # run reload_config
   /var/scripts/reload_config.sh
   if [ "$?" != '0' ]; then


### PR DESCRIPTION
なぜか今になって nginx が起動できなくなっていて、`libshmem_ipc_2.so` がないのが原因でした。
```
root@82a07990b672:/var/scripts# /etc/init.d/nginx status
 * nginx is not running
root@82a07990b672:/var/scripts# /etc/init.d/nginx start
 * Starting nginx nginx                                                                                                                                                                                  [fail]
root@82a07990b672:/var/scripts# /etc/init.d/nginx status
 * nginx is not running
root@82a07990b672:/var/scripts# nginx -t
2026/07/09 11:12:26 [emerg] 174#174: dlopen() "/usr/lib/nginx/modules/ngx_cp_attachment_module.so" failed (libshmem_ipc_2.so: cannot open shared object file: No such file or directory) in /etc/nginx/nginx.con
f:1
nginx: configuration file /etc/nginx/nginx.conf test failed
root@82a07990b672:/var/scripts#
```

また、reload_config 開始前に nginx の起動待ちを行うようにし、起動できていないようなら異常終了するようにしました。